### PR TITLE
Update to Mobx 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "json-stringify-safe": "5.0.1",
     "lodash": "4.16.6",
-    "query-string": "^5.0.1",
     "safe-access": "0.1.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -45,12 +45,13 @@
     }
   },
   "dependencies": {
+    "deprecated": "^0.0.2",
     "json-stringify-safe": "5.0.1",
     "lodash": "4.16.6",
     "safe-access": "0.1.0"
   },
   "peerDependencies": {
-    "mobx": "^4.2.0"
+    "mobx": "^2.5.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "babel-cli": "6.18.0",

--- a/package.json
+++ b/package.json
@@ -47,10 +47,11 @@
   "dependencies": {
     "json-stringify-safe": "5.0.1",
     "lodash": "4.16.6",
+    "query-string": "^5.0.1",
     "safe-access": "0.1.0"
   },
   "peerDependencies": {
-    "mobx": "^2.5.0 || ^3.0.0"
+    "mobx": "^4.2.0"
   },
   "devDependencies": {
     "babel-cli": "6.18.0",
@@ -76,7 +77,7 @@
     "eslint-plugin-react": "6.6.0",
     "ghooks": "1.3.2",
     "json-loader": "0.5.4",
-    "mobx": "^2.6.0",
+    "mobx": "^4.2.0",
     "mocha": "3.1.2",
     "nyc": "8.4.0",
     "rimraf": "2.5.4",

--- a/src/decorators/toggle.js
+++ b/src/decorators/toggle.js
@@ -1,6 +1,7 @@
 import { action } from 'mobx';
+import { deprecated } from 'deprecated';
 
-export function toggle(...args) {
+function toggleFn(...args) {
   const fnName = args[0] || 'active';
   const propKey = args[1] || 'isActive';
   return action((target) => {
@@ -9,8 +10,18 @@ export function toggle(...args) {
       [fnName]: action((flag = null) => {
         if (flag === true) return Object.assign(target.prototype, { [propKey]: true });
         if (flag === false) return Object.assign(target.prototype, { [propKey]: false });
-        return Object.assign(target.prototype, { [propKey]: !target.prototype[propKey] });
+        return Object.assign(target.prototype, {
+          [propKey]: !target.prototype[propKey],
+        });
       }),
     });
   });
 }
+
+const toggle = deprecated.method(
+  'The `@toggle` decorator is incompatible with mobx 4 and has been deprecated. It will be removed in the next major version.',
+  console.error, // eslint-disable-line no-console
+  toggleFn,
+);
+
+export default toggle;


### PR DESCRIPTION
I've started migrating my project to Mobx v4 (v4.2.0) and have run into some issues along the way. The main issue I've found in `rfx-core` is that the `@toggle` decorator no longer works.

In v4, the `@observable` decorator moves the prop from the class to the instance. Since `@toggle` decorates the class, an issue arises that throws an error preventing further page loading.

> Error: [mobx] Property 'isOpen' of '[object Object]' was accessed through the prototype chain. Use 'decorate' instead to declare the prop or access it statically through it's owner

From the mobx gitter channel:

> Michel Weststrate @mweststrate 12:15
> @pdfowler yeah decorators don't compose atm, as @observable etc will redefine the property and move it from the class to the instance. Which unfortunately cannot be expressed neatly in the current decorators implementations (the current stage 2 proposal fixes that)

### TODO:

- [ ] Re-Implement `@toggle` to be compatible with mobx-4
- [x] Confirm that `@extend` works as intended